### PR TITLE
monorepo support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -338,8 +338,10 @@ runs:
           git checkout ${{ steps.get_base.outputs.base_sha }}
           echo "Checking out new fix branch $FIX_BRANCH"
           git checkout -b $FIX_BRANCH
+          cd ${{ inputs.project_path }}
           lekko gen -r ~/lekko
           git add ${{ steps.read_dot_lekko.outputs.lekko_path }}
+          cd ${GITHUB_WORKSPACE}
           FIX_MESSAGE="Pull from ${{ steps.read_dot_lekko.outputs.repository }}@$(git rev-parse --short ${LEKKO_SHA})"
           git commit -m "$FIX_MESSAGE"
           git push -u origin $FIX_BRANCH

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   api_key:
     description: Lekko API key for the team/repository.
     required: true
+  project_path:
+    description: Path to a project that uses lekko (contains a .lekko file)
+    default: .
   team_name:
     description: Lekko team name. Uses the GitHub organization name by default. Only required if your Lekko team name is different from your GitHub organization name.
     required: false
@@ -39,6 +42,7 @@ runs:
         export OWNER_NAME="${{ github.event.repository.owner.login }}"
         export REPO_NAME="${{ github.event.repository.name }}"
         export TEAM_NAME="${{ inputs.team_name != '' && inputs.team_name || github.event.repository.owner.login }}"
+        export PROJECT_PATH="${{ inputs.project_path }}"
         ${GITHUB_ACTION_PATH}/get_token.sh
     # We re-checkout the code repo using the Lekko-issued token for git remove permissions available to the app (e.g. write)
     - name: Re-checkout with token
@@ -149,11 +153,15 @@ runs:
     - name: Read Lekko configuration
       id: read_dot_lekko
       shell: bash
-      run: ${GITHUB_ACTION_PATH}/read_dot_lekko.sh
+      run: |
+        export PROJECT_PATH="${{ inputs.project_path }}"
+        ${GITHUB_ACTION_PATH}/read_dot_lekko.sh
     - name: Read Lekko configuration at base
       id: read_dot_lekko_base
       shell: bash
-      run: ${GITHUB_ACTION_PATH}/read_dot_lekko_base.sh ${{ steps.get_base.outputs.base_sha }} ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }}
+      run: |
+        export PROJECT_PATH="${{ inputs.project_path }}"
+        ${GITHUB_ACTION_PATH}/read_dot_lekko_base.sh ${{ steps.get_base.outputs.base_sha }} ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }}
     - name: Checkout Lekko repo
       uses: actions/checkout@v4
       with:
@@ -173,6 +181,7 @@ runs:
       run: |
         echo "pre-check reset"
         git reset --hard && git clean -fd
+        cd ${{ inputs.project_path }}
         if ! lekko bisync -r ~/lekko; then
           echo -e "Lekko codegen check failed.\n\nPlease run \`lekko bisync\`, fix the reported issues, and try again." > ~/info-body
         else
@@ -181,6 +190,7 @@ runs:
             echo -e "Detected unchecked Lekko codegen changes.\n\nPlease run \`lekko bisync\` and commit the results." > ~/info-body
           fi
         fi
+        cd ${GITHUB_WORKSPACE}
         if [[ -s ~/info-body ]] && [[ "${{ github.event_name }}" == "pull_request" ]]; then
           cat ~/info-body
           gh pr comment ${{ github.event.pull_request.number }} --edit-last --body-file ~/info-body || gh pr comment ${{ github.event.pull_request.number }} --body-file ~/info-body
@@ -201,7 +211,9 @@ runs:
       id: get_diff
       if: steps.check_bisync.outputs.head_equal != 'true'
       shell: bash
-      run: ${GITHUB_ACTION_PATH}/get_diff.sh ${{ steps.get_base.outputs.base_sha }} ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }} ${{ steps.read_dot_lekko_base.outputs.new_lekko }}
+      run: |
+        export PROJECT_PATH="${{ inputs.project_path }}"
+        ${GITHUB_ACTION_PATH}/get_diff.sh ${{ steps.get_base.outputs.base_sha }} ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.after }} ${{ steps.read_dot_lekko_base.outputs.new_lekko }}
       env:
         GH_TOKEN: ${{ steps.get_token.outputs.token }}
     # TODO: If a PR goes from has Lekko changes -> no changes, we should try to delete or update the comment
@@ -314,7 +326,9 @@ runs:
             exit 1
           fi
           echo "Collecting diff info..."
+          cd ${{ inputs.project_path }}
           lekko bisync -r ~/lekko
+          cd ${GITHUB_WORKSPACE}
           git reset --hard && git clean -fd
           cd ~/lekko
           git add .

--- a/get_diff.sh
+++ b/get_diff.sh
@@ -14,11 +14,13 @@ if [[ "$1" != "0000000000000000000000000000000000000000" ]]; then
     git checkout $1
     echo "pre-sync base"
     set +e
+    cd ${PROJECT_PATH}
     if ! lekko bisync -r ~/lekko; then
       # If bisync fails on base commit, ignore and try to proceed
       # This might result in detecting "unnecessary" additions, but hopefully fix PR should help resolve that
       echo "Warning: bisync failed on base ($1). The current state of your Lekko repository will be used as the base of changes."
     fi
+    cd ${GITHUB_WORKSPACE}
     set -e
   else
     echo "Base did not have Lekko"
@@ -34,7 +36,9 @@ git commit --allow-empty -m "Reset configs to base"
 cd ${GITHUB_WORKSPACE}
 git checkout $2
 echo "pre-sync head"
+cd ${PROJECT_PATH}
 lekko bisync -r ~/lekko
+cd ${GITHUB_WORKSPACE}
 git reset --hard && git clean -fd
 cd ~/lekko
 git checkout -b ${GITHUB_REPOSITORY}-head

--- a/read_dot_lekko.sh
+++ b/read_dot_lekko.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-cd ${GITHUB_WORKSPACE}
+cd ${GITHUB_WORKSPACE}/${PROJECT_PATH}
 DOT_LEKKO="$(lekko conf)"
 echo "repository="$(echo "$DOT_LEKKO" | jq '.repository' --raw-output)"" >> $GITHUB_OUTPUT
 echo "lekko_path="$(echo "$DOT_LEKKO" | jq '.lekkoPath' --raw-output)"" >> $GITHUB_OUTPUT

--- a/read_dot_lekko_base.sh
+++ b/read_dot_lekko_base.sh
@@ -4,11 +4,13 @@ cd ${GITHUB_WORKSPACE}
 if [[ "$1" != "0000000000000000000000000000000000000000" ]]; then
   git reset --hard && git clean -fd
   git checkout $1
+  cd ${PROJECT_PATH}
   if ! lekko conf; then
     # lekko conf failed - assume this means .lekko did not exist at base
     echo "Current change introduced Lekko"
     echo "new_lekko=true" >> $GITHUB_OUTPUT
   fi
+  cd ${GITHUB_WORKSPACE}
 else
   echo "Base points to null commit"
   echo "new_lekko=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In monorepo we can use it like this (for a go project):
```
name: lekko
on:
  pull_request:
    branches:
      - main
    paths:
      - "lekko-go/**"
  push:
    branches:
      - main
    paths:
      - "lekko-go/**"
permissions:
  contents: read
jobs:
  push:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-go@v5
        with:
          go-version-file: ./lekko-go/go.mod
      - uses: lekkodev/push-action@spass/monorepo-support
        with:
          api_key: ${{ secrets.LEKKO_API_KEY }}
          project_path: lekko-go
```